### PR TITLE
Explicitly set pyproject build-system build-backend to setuptools build_meta

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
 requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["forum_dl", "forum_dl.extractors", "forum_dl.writers"]


### PR DESCRIPTION
It is better to be explicit than implicit.

The default is the setuptools legacy build backend but some versions of
setuptools might not have the setuptools legacy build backend and some
tools might not set a default build backend.

See-also: https://pip.pypa.io/en/stable/reference/build-system/pyproject-toml/#fallback-behaviour
See-also: https://salsa.debian.org/python-team/tools/pypi2deb/-/merge_requests/18
See-also: https://github.com/pypa/setuptools/issues/1694
