### PR TITLE
Adding Time Sleep

### DIFF
--- a/forum_dl/__init__.py
+++ b/forum_dl/__init__.py
@@ -42,6 +42,7 @@ def main():
                 warc_output=warc_output,
                 user_agent=args.user_agent,
                 get_urls=args.get_urls,
+                time_sleep=args.time_sleep
             ),
             extractor_options=ExtractorOptions(
                 path=False,

--- a/forum_dl/options.py
+++ b/forum_dl/options.py
@@ -47,6 +47,13 @@ def build_parser():
         help="HTTP connection timeout",
     )
     session.add_argument(
+        "--time-sleep",
+        metavar="SECONDS",
+        dest="time_sleep",
+        default="5",
+        help="time to sleep between request to avoid rate limit",
+    )
+    session.add_argument(
         "-R",
         "--retries",
         metavar="N",

--- a/forum_dl/session.py
+++ b/forum_dl/session.py
@@ -28,6 +28,7 @@ class SessionOptions(BaseModel):
     warc_output: str
     user_agent: str
     get_urls: bool
+    time_sleep: int
 
 
 class Session:
@@ -83,6 +84,8 @@ class Session:
             should_retry=should_retry,
             **kwargs,
         )
+
+        time.sleep(self._options.time_sleep)
         response.raise_for_status()
 
         return response


### PR DESCRIPTION
Time sleep is added to avoid the rate limit that sometimes appears in most scrapping processes. 

Usage:
`forum-dl [url] -o [output.json] --time-sleep [second : int]`

Example:
`forum-dl "https://forum.dronedeploy.com/c/feature-requests" -o test.json --time-sleep 3`
